### PR TITLE
Fix Joomla 6 compatibility of the module configuration form

### DIFF
--- a/elements/fclanguage.php
+++ b/elements/fclanguage.php
@@ -18,6 +18,9 @@
 
 // Check to ensure this file is included in Joomla!
 defined('_JEXEC') or die('Restricted access');
+// DS is not a Joomla core constant (it is defined by FLEXIcontent), make sure it exists
+if (!defined('DS')) define('DS', DIRECTORY_SEPARATOR);
+
 use \Joomla\CMS\Component\ComponentHelper;
 
 jimport( 'joomla.application.component.controller' );

--- a/elements/fields.php
+++ b/elements/fields.php
@@ -18,6 +18,9 @@
 
 // Check to ensure this file is included in Joomla!
 defined('_JEXEC') or die('Restricted access');
+// DS is not a Joomla core constant (it is defined by FLEXIcontent), make sure it exists
+if (!defined('DS')) define('DS', DIRECTORY_SEPARATOR);
+
 use \Joomla\CMS\Component\ComponentHelper;
 
 jimport( 'joomla.application.component.controller' );

--- a/elements/filters.php
+++ b/elements/filters.php
@@ -18,6 +18,9 @@
 
 // Check to ensure this file is included in Joomla!
 defined('_JEXEC') or die('Restricted access');
+// DS is not a Joomla core constant (it is defined by FLEXIcontent), make sure it exists
+if (!defined('DS')) define('DS', DIRECTORY_SEPARATOR);
+
 use \Joomla\CMS\Component\ComponentHelper;
 
 jimport( 'joomla.application.component.controller' );

--- a/elements/flexicategories.php
+++ b/elements/flexicategories.php
@@ -16,6 +16,9 @@
  * GNU General Public License for more details.
  */
 defined('_JEXEC') or die('Restricted access');
+// DS is not a Joomla core constant (it is defined by FLEXIcontent), make sure it exists
+if (!defined('DS')) define('DS', DIRECTORY_SEPARATOR);
+
 use \Joomla\CMS\Component\ComponentHelper;
 
 jimport( 'joomla.application.component.controller' );

--- a/elements/iconpicker.php
+++ b/elements/iconpicker.php
@@ -14,18 +14,11 @@
 * GNU General Public License for more details.
 **/
 
-defined('JPATH_PLATFORM') or die;
-require_once(JPATH_ROOT.DS.'components'.DS.'com_flexicontent'.DS.'classes'.DS.'flexicontent.helper.php');
+// JPATH_PLATFORM has been removed in Joomla 6, use the regular entry point guard
+defined('_JEXEC') or die;
 
-
+use Joomla\CMS\Form\FormField;
 use Joomla\CMS\HTML\HTMLHelper;
-use \Joomla\CMS\Form\FormHelper;
-use \Joomla\CMS\Form\FormField;
-FormHelper::loadFieldClass('list');   // JFormFieldList
-HTMLHelper::_('stylesheet', 'media/mod_flexiadmin/css/admin-style.css');
-HTMLHelper::_('stylesheet', 'media/mod_flexiadmin/css/style.css');
-HTMLHelper::_('script', 'media/mod_flexiadmin/js/universal-icon-picker.min.js');
-
 
 class JFormFieldIconpicker extends FormField
 {
@@ -33,31 +26,38 @@ class JFormFieldIconpicker extends FormField
   // getLabel() left out
   public function getInput()
   {
+    HTMLHelper::_('stylesheet', 'media/mod_flexiadmin/css/admin-style.css');
+    HTMLHelper::_('stylesheet', 'media/mod_flexiadmin/css/style.css');
+    HTMLHelper::_('script', 'media/mod_flexiadmin/js/universal-icon-picker.min.js');
+
+    $id    = htmlspecialchars($this->id, ENT_QUOTES, 'UTF-8');
+    $name  = htmlspecialchars($this->name, ENT_QUOTES, 'UTF-8');
+    $value = htmlspecialchars((string) $this->value, ENT_QUOTES, 'UTF-8');
 
     $iconlist = ' <div class="input-group mb-3">
-    <span class="input-group-text" id="' . $this->id . '-icon">
-    <i class="fa '.$this->value.'"></i>
+    <span class="input-group-text" id="' . $id . '-icon">
+    <i class="fa '.$value.'"></i>
     </span>
-    <input id="' . $this->id . '-wrapper" value="'.$this->value.'" name="' . $this->name . '-wrapper"  class="form-control"/><button id="' . $this->id . '-clear" class="btn btn-outline-secondary">
+    <input id="' . $id . '-wrapper" value="'.$value.'" name="' . $name . '-wrapper"  class="form-control"/><button type="button" id="' . $id . '-clear" class="btn btn-outline-secondary">
     Reset
     </button></div>';
     $iconlist .= "
     <script>
         document.addEventListener('DOMContentLoaded', function(event) {
-        var uip = new UniversalIconPicker('#" . $this->id . "-wrapper', {
+        var uip = new UniversalIconPicker('#" . $id . "-wrapper', {
             iconLibraries: [
               'font-awesome.min.json'
             ],
             iconLibrariesCss: [
             '../../../media/mod_flexiadmin/css/font-awesome.min.css'
             ],
-            resetSelector: '#" . $this->id . "-clear',  // must be an ID or '' if no reset button
+            resetSelector: '#" . $id . "-clear',  // must be an ID or '' if no reset button
             onSelect: function(jsonIconData) {
-            document.getElementById('" . $this->id . "-wrapper').value = jsonIconData.iconClass;
-            document.getElementById('" . $this->id . "-icon').innerHTML = jsonIconData.iconHtml;
+            document.getElementById('" . $id . "-wrapper').value = jsonIconData.iconClass;
+            document.getElementById('" . $id . "-icon').innerHTML = jsonIconData.iconHtml;
             },
             onReset: function() {
-              document.getElementById('" . $this->id . "-wrapper').value = '';
+              document.getElementById('" . $id . "-wrapper').value = '';
             }
             });
         });

--- a/elements/qfcategory.php
+++ b/elements/qfcategory.php
@@ -18,6 +18,9 @@
 
 // Check to ensure this file is included in Joomla!
 defined('_JEXEC') or die('Restricted access');
+// DS is not a Joomla core constant (it is defined by FLEXIcontent), make sure it exists
+if (!defined('DS')) define('DS', DIRECTORY_SEPARATOR);
+
 use \Joomla\CMS\Component\ComponentHelper;
 
 jimport( 'joomla.application.component.controller' );

--- a/elements/separator.php
+++ b/elements/separator.php
@@ -18,6 +18,9 @@
 
 // Check to ensure this file is included in Joomla!
 defined('_JEXEC') or die('Restricted access');
+// DS is not a Joomla core constant (it is defined by FLEXIcontent), make sure it exists
+if (!defined('DS')) define('DS', DIRECTORY_SEPARATOR);
+
 use \Joomla\CMS\Component\ComponentHelper;
 
 jimport( 'joomla.application.component.controller' );

--- a/elements/types.php
+++ b/elements/types.php
@@ -18,6 +18,9 @@
 
 // Check to ensure this file is included in Joomla!
 defined('_JEXEC') or die('Restricted access');
+// DS is not a Joomla core constant (it is defined by FLEXIcontent), make sure it exists
+if (!defined('DS')) define('DS', DIRECTORY_SEPARATOR);
+
 use \Joomla\CMS\Component\ComponentHelper;
 
 jimport( 'joomla.application.component.controller' );

--- a/helper.php
+++ b/helper.php
@@ -18,6 +18,9 @@
 //blocage des accés directs sur ce script
 defined('_JEXEC') or die('Accés interdit');
 
+// DS is not a Joomla core constant (it is defined by FLEXIcontent), make sure it exists
+if (!defined('DS')) define('DS', DIRECTORY_SEPARATOR);
+
 use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;

--- a/mod_flexiadmin.xml
+++ b/mod_flexiadmin.xml
@@ -5,7 +5,7 @@
     <creationDate>dec 2021</creationDate>
     <authorEmail>yannick@com3elles.com</authorEmail>
     <authorUrl>www.com3elles.com</authorUrl>
-    <version>3.2</version>
+    <version>3.3</version>
     <copyright>Copyright (C) 2005 - 2022 Open Source Matters. All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>MOD_FLEXI_ADMIN_INTRO</description>

--- a/tmpl/default.php
+++ b/tmpl/default.php
@@ -19,6 +19,9 @@
 //blocage des accés directs sur ce script
 defined('_JEXEC') or die('Accés interdit');
 
+// DS is not a Joomla core constant (it is defined by FLEXIcontent), make sure it exists
+if (!defined('DS')) define('DS', DIRECTORY_SEPARATOR);
+
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;

--- a/update.xml
+++ b/update.xml
@@ -6,14 +6,14 @@
 		<element>mod_flexiadmin</element>
 		<type>module</type>
 		<client>administrator</client>
-		<version>3.2</version>
+		<version>3.3</version>
 
 		<infourl title="FAQ">
 			https://github.com/micker/mod_flexiadmin/wiki
 		</infourl>
 
 		<downloads>
-			<downloadurl type="full" format="zip">https://github.com/micker/mod_flexiadmin/archive/v3.2.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://github.com/micker/mod_flexiadmin/archive/v3.3.zip</downloadurl>
 		</downloads>
 
 		<tags>
@@ -22,7 +22,7 @@
 
 		<maintainer>Yannick berges</maintainer>
 		<maintainerurl>http://www.com3elles.org</maintainerurl>
-		<targetplatform name="joomla" version="((4\.(0|1|2|3|4|5|6|7|8|9))|(5\.(0|1|2|3|4|5|6|7|8|9)))"/>
+		<targetplatform name="joomla" version="[456]\.\d+"/>
 
 	</update>
 </updates>


### PR DESCRIPTION
## Symptom

On Joomla 6, opening the module's configuration form makes the page stop rendering mid-way — no error message, no log entry, just truncated HTML returned with an HTTP 200.

## Root cause

`elements/iconpicker.php` guarded itself with:

```php
defined('JPATH_PLATFORM') or die;
```

`JPATH_PLATFORM` was defined in `libraries/bootstrap.php` up to Joomla 5 and **has been removed in Joomla 6**. The guard therefore always fails, and `die` runs. Because `die` is not a `Throwable`, Joomla can neither catch it nor render an error page — hence the silent truncation, right at the first subform containing an iconpicker field.

## Second blocker

While reproducing, the form also fataled with `Undefined constant "DS"` in `elements/separator.php` whenever the FLEXIcontent system plugin is not enabled. `DS` has not been a Joomla core constant for a long time; FLEXIcontent defines it, and its own files carry an `if (!defined('DS'))` guard. The copies in this module did not. Added the same guard to the 7 element wrappers, `helper.php` and `tmpl/default.php`.

## Changes

**`elements/iconpicker.php`**
- `JPATH_PLATFORM` → `_JEXEC` guard
- dropped the unused `require_once` of `flexicontent.helper.php` and the unused `FormHelper::loadFieldClass('list')` — the field no longer depends on FLEXIcontent being loaded at all
- CSS/JS registration moved into `getInput()` instead of running at file inclusion time
- `id`, `name` and `value` escaped in the emitted markup
- `type="button"` on the Reset button, which otherwise submitted the whole form on click

**Version / update server**
- `3.2` → `3.3` in `mod_flexiadmin.xml` and `update.xml`
- `update.xml` targetplatform `((4\.(0|…|9))|(5\.(0|…|9)))` → `[456]\.\d+`

That last one matters on its own: Joomla matches it with `preg_match('/^' . $version . '/', JVERSION)`, so as it stood **no Joomla 6 site would ever have been offered this update**. The new pattern also survives two-digit minors (5.10), which the enumerated form would eventually have broken on.

## Verification

Tested against clean Docker installs, module installed from the built package, configuration form fetched over HTTP:

| | Joomla 4.4.14 / PHP 8.2 | Joomla 6.1.2 / PHP 8.3 |
|---|---|---|
| Configuration form | 200 — 210 081 B, `</html>` present | 200 — 212 346 B, `</html>` present |
| iconpicker fields rendered | 2 | 2 |
| `universal-icon-picker.min.js` loaded | yes | yes |
| PHP error | none | none |
| Module on admin dashboard | renders | renders |

Before the fix, the same Joomla 6 request returned 200 with 25 190 B and no `</html>`.

Backwards compatibility with Joomla 4 is preserved: nothing here uses an API newer than Joomla 4, and the legacy `JFormFieldIconpicker` class name still resolves in Joomla 6 via the `JForm<Entity><Type>` fallback in `FormHelper::loadClass()`.

## Out of scope

FLEXIcontent itself is not Joomla 6 ready — its `script.php` calls `$app->getCfg()`, removed in Joomla 6, which aborts its install script. Unrelated to this module.